### PR TITLE
Fix profile lookup issue

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -264,6 +264,10 @@ export type Database = {
         Args: { "": string } | { "": unknown }
         Returns: unknown
       }
+      get_profile_id_by_url_param: {
+        Args: { url_param_input: string }
+        Returns: string
+      }
       get_public_profile: {
         Args: { profile_url_param: string }
         Returns: {

--- a/src/services/homePageService.ts
+++ b/src/services/homePageService.ts
@@ -171,19 +171,16 @@ export async function getHomePageSettingsByUrlParam(urlParam: string): Promise<H
   try {
     console.log(`Fetching home page settings for URL parameter: ${urlParam}`);
     
-    // First get the profile ID for this URL parameter
-    const { data: profile, error: profileError } = await supabase
-      .from('profiles')
-      .select('id')
-      .eq('url_param', urlParam)
-      .single();
+    // Use security definer function to get profile ID for this URL parameter
+    const { data: profileId, error: profileError } = await supabase
+      .rpc('get_profile_id_by_url_param', { url_param_input: urlParam });
     
-    if (profileError || !profile) {
+    if (profileError || !profileId) {
       console.error('Error fetching profile by URL parameter:', profileError);
       return null;
     }
     
-    const settings = await getHomePageSettingsByProfileId(profile.id);
+    const settings = await getHomePageSettingsByProfileId(profileId);
     return settings;
   } catch (error) {
     console.error('Exception fetching home page settings by URL parameter:', error);

--- a/supabase/migrations/20250823134924_bbd4809e-6837-4064-8fdc-643e3c9c616d.sql
+++ b/supabase/migrations/20250823134924_bbd4809e-6837-4064-8fdc-643e3c9c616d.sql
@@ -1,0 +1,18 @@
+-- Create a security definer function to get profile ID by URL parameter
+-- This allows public access to resolve URL parameters to profile IDs
+CREATE OR REPLACE FUNCTION public.get_profile_id_by_url_param(url_param_input text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    profile_id_result uuid;
+BEGIN
+    SELECT id INTO profile_id_result
+    FROM profiles
+    WHERE url_param = url_param_input;
+    
+    RETURN profile_id_result;
+END;
+$$;


### PR DESCRIPTION
Fixed the profile lookup issue by creating a Supabase security definer function `get_profile_id_by_url_param` to securely retrieve the profile ID by URL parameter, allowing public access for this specific lookup. This resolves the 406 error and ensures the correct home page settings are displayed.